### PR TITLE
Make operations cancel-able via an optional parameter containing an `AbortSignal`

### DIFF
--- a/iamap.js
+++ b/iamap.js
@@ -363,7 +363,7 @@ class IAMap {
           return updateBucket(this, data.elementAt, -1, key, value, options)
         }
       } else if (link) {
-        const child = await load(this.store, link.element.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, link.element.link, this.depth + 1, addOptions(this.config, options))
         assert(!!child)
         const newChild = await child.set(key, value, options, hash)
         return updateNode(this, link.elementAt, newChild, options)
@@ -405,7 +405,7 @@ class IAMap {
         }
         return undefined // not found
       } else if (link) {
-        const child = await load(this.store, link.element.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, link.element.link, this.depth + 1, addOptions(this.config, options))
         assert(!!child)
         return await child.get(key, options, hash)
         /* c8 ignore next 3 */
@@ -486,14 +486,14 @@ class IAMap {
             if (lastInBucket) {
               newMap = setBit(newMap, bitpos, false)
             }
-            return create(this.store, { ...this.config, signal: options?.signal }, newMap, this.depth, newData)
+            return create(this.store, addOptions(this.config, options), newMap, this.depth, newData)
           }
         } else {
           // key would be located here according to hash, but we don't have it
           return this
         }
       } else if (link) {
-        const child = await load(this.store, link.element.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, link.element.link, this.depth + 1, addOptions(this.config, options))
         assert(!!child)
         const newChild = await child.delete(key, options, hash)
         if (this.store.isEqual(newChild.id, link.element.link)) { // no modification
@@ -539,7 +539,7 @@ class IAMap {
       if (e.bucket) {
         c += e.bucket.length
       } else {
-        const child = await load(this.store, e.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, e.link, this.depth + 1, addOptions(this.config, options))
         c += await child.size()
       }
     }
@@ -562,7 +562,7 @@ class IAMap {
           yield kv.key
         }
       } else {
-        const child = await load(this.store, e.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, e.link, this.depth + 1, addOptions(this.config, options))
         yield * child.keys()
       }
     }
@@ -585,7 +585,7 @@ class IAMap {
           yield kv.value
         }
       } else {
-        const child = await load(this.store, e.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, e.link, this.depth + 1, addOptions(this.config, options))
         yield * child.values()
       }
     }
@@ -608,7 +608,7 @@ class IAMap {
           yield { key: kv.key, value: kv.value }
         }
       } else {
-        const child = await load(this.store, e.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, e.link, this.depth + 1, addOptions(this.config, options))
         yield * child.entries()
       }
     }
@@ -627,7 +627,7 @@ class IAMap {
     yield this.id
     for (const e of this.data) {
       if (e.link) {
-        const child = await load(this.store, e.link, this.depth + 1, { ...this.config, signal: options?.signal })
+        const child = await load(this.store, e.link, this.depth + 1, addOptions(this.config, options))
         yield * child.ids()
       }
     }
@@ -825,7 +825,7 @@ async function addNewElement (node, bitpos, key, value, options) {
   const newData = node.data.slice()
   newData.splice(insertAt, 0, new Element([new KV(key, value)]))
   const newMap = setBit(node.map, bitpos, true)
-  return create(node.store, { ...node.config, signal: options?.signal }, newMap, node.depth, newData)
+  return create(node.store, addOptions(node.config, options), newMap, node.depth, newData)
 }
 
 /**
@@ -861,7 +861,7 @@ async function updateBucket (node, elementAt, bucketAt, key, value, options) {
   }
   const newData = node.data.slice()
   newData[elementAt] = newElement
-  return create(node.store, { ...node.config, signal: options?.signal }, node.map, node.depth, newData)
+  return create(node.store, addOptions(node.config, options), node.map, node.depth, newData)
 }
 
 /**
@@ -887,7 +887,7 @@ async function replaceBucketWithNode (node, elementAt, options) {
   newNode = await save(node.store, newNode, options)
   const newData = node.data.slice()
   newData[elementAt] = new Element(undefined, newNode.id)
-  return create(node.store, { ...node.config, signal: options?.signal }, node.map, node.depth, newData)
+  return create(node.store, addOptions(node.config, options), node.map, node.depth, newData)
 }
 
 /**
@@ -905,7 +905,7 @@ async function updateNode (node, elementAt, newChild, options) {
   const newElement = new Element(undefined, newChild.id)
   const newData = node.data.slice()
   newData[elementAt] = newElement
-  return create(node.store, { ...node.config, signal: options?.signal }, node.map, node.depth, newData)
+  return create(node.store, addOptions(node.config, options), node.map, node.depth, newData)
 }
 
 // take a node, extract all of its local entries and put them into a new node with a single
@@ -951,7 +951,7 @@ function collapseIntoSingleBucket (node, hash, elementAt, bucketIndex, options) 
   }, /** @type {KV[]} */ [])
   newBucket.sort((a, b) => byteCompare(a.key, b.key))
   const newElement = new Element(newBucket)
-  return create(node.store, { ...node.config, signal: options?.signal }, newMap, 0, [newElement])
+  return create(node.store, addOptions(node.config, options), newMap, 0, [newElement])
 }
 
 // simple delete from an existing bucket in this node
@@ -1011,7 +1011,7 @@ async function collapseNodeInline (node, bitpos, newNode, options) {
   const newData = node.data.slice()
   newData[elementIndex] = newElement
 
-  return create(node.store, { ...node.config, signal: options?.signal }, node.map, node.depth, newData)
+  return create(node.store, addOptions(node.config, options), node.map, node.depth, newData)
 }
 
 /**
@@ -1068,6 +1068,16 @@ function buildConfig (options) {
   }
 
   return config
+}
+
+/**
+ * @ignore
+ * @param {Config} config
+ * @param {AbortOptions} [options]
+ * @returns {Options & AbortOptions}
+ */
+function addOptions (config, options) {
+  return { ...config, signal: options == null ? undefined : options.signal }
 }
 
 /**

--- a/iamap.js
+++ b/iamap.js
@@ -100,6 +100,20 @@ async function create (store, options, map, depth, data) {
 }
 
 /**
+ *
+ * Create a IAMap inner node at positive, nonzero depth.
+ *
+ * @name iamap.load
+ * @function
+ * @async
+ * @template T
+ * @param {Store<T>} store - A backing store for this Map. See {@link iamap.create}.
+ * @param {any} id - An content address / ID understood by the backing `store`.
+ * @param {number} [depth=0]
+ * @param {Options} [options]
+ *
+ * //**
+ *
  * ```js
  * let map = await iamap.load(store, id)
  * ```
@@ -112,8 +126,8 @@ async function create (store, options, map, depth, data) {
  * @template T
  * @param {Store<T>} store - A backing store for this Map. See {@link iamap.create}.
  * @param {any} id - An content address / ID understood by the backing `store`.
- * @param {number} [depth=0]
- * @param {Options} [options]
+ * @param {0 | undefined} [depth=0]
+ * @param {AbortOptions} [options]
  */
 async function load (store, id, depth = 0, options) {
   // depth and options are internal arguments that the user doesn't need to interact with

--- a/interface.ts
+++ b/interface.ts
@@ -9,7 +9,7 @@ export interface Store<T> {
 export interface Options extends AbortOptions {
   bitWidth?: number,
   bucketSize?: number,
-  hashAlg?: number
+  hashAlg: number
 }
 
 export interface Config {

--- a/interface.ts
+++ b/interface.ts
@@ -6,10 +6,10 @@ export interface Store<T> {
   isEqual(link1: T, link2: T): boolean,
 }
 
-export interface Options {
+export interface Options extends AbortOptions {
   bitWidth?: number,
   bucketSize?: number,
-  hashAlg: number
+  hashAlg?: number
 }
 
 export interface Config {

--- a/interface.ts
+++ b/interface.ts
@@ -1,7 +1,7 @@
 // store using a link type `T`
 export interface Store<T> {
-  save(node: any): Promise<T>,
-  load(id: T): Promise<any>,
+  save(node: any, options?: AbortOptions): Promise<T>,
+  load(id: T, options?: AbortOptions): Promise<any>,
   isLink(link: T): boolean,
   isEqual(link1: T, link2: T): boolean,
 }
@@ -16,6 +16,10 @@ export interface Config {
   bitWidth: number,
   bucketSize: number,
   hashAlg: number
+}
+
+export interface AbortOptions {
+  signal?: AbortSignal
 }
 
 export type SerializedKV = [Uint8Array, any]

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -286,7 +286,7 @@ describe('Basics', () => {
       assert.strictEqual(child.data.length, 1)
       assert.strictEqual(child.data[0].bucket, null)
       assert.strictEqual(typeof child.data[0].link, 'number')
-      child = await iamap.load(store, child.data[0].link, i + 1, options)
+      child = await iamap.loadInternal(store, child.data[0].link, i + 1, options)
     }
     // at the 7th level they all have a different hash portion: 1,2,3 so they should be in separate buckets
     assert.strictEqual(child.data.length, 3)
@@ -331,7 +331,7 @@ describe('Basics', () => {
       assert.strictEqual(child.data.length, 1)
       assert.strictEqual(child.data[0].bucket, null)
       assert.strictEqual(typeof child.data[0].link, 'number')
-      child = await iamap.load(store, child.data[0].link, i + 1, options)
+      child = await iamap.loadInternal(store, child.data[0].link, i + 1, options)
     }
 
     assert.strictEqual(toHex(child.map), toHex(Uint8Array.from([0b101, 0]))) // data at position 2 and 0
@@ -376,7 +376,7 @@ describe('Basics', () => {
       assert.strictEqual(child.data.length, 1)
       assert.strictEqual(child.data[0].bucket, null)
       assert.strictEqual(typeof child.data[0].link, 'number')
-      child = await iamap.load(store, child.data[0].link, i + 1, options)
+      child = await iamap.loadInternal(store, child.data[0].link, i + 1, options)
     }
 
     // last level should have 2 buckets but with a bucket in 0 and a node in 2
@@ -432,7 +432,7 @@ describe('Basics', () => {
       assert.strictEqual(child.data.length, 1)
       assert.strictEqual(child.data[0].bucket, null)
       assert.strictEqual(typeof child.data[0].link, 'number')
-      child = await iamap.load(store, child.data[0].link, i + 1, options)
+      child = await iamap.loadInternal(store, child.data[0].link, i + 1, options)
     }
 
     // last level should have 2 buckets but with a bucket in 0 and a node in 2

--- a/test/errors-test.js
+++ b/test/errors-test.js
@@ -70,9 +70,9 @@ describe('Errors', () => {
     await assert.isFulfilled(iamap.create(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 4, bucketSize: 2 }))
     await assert.isFulfilled(iamap.create(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 4, bucketSize: 16 }))
     // @ts-ignore
-    await assert.isRejected(iamap.create(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 4, bucketSize: 16 }, 'blerk'))
-    await assert.isRejected(iamap.create(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 10, bucketSize: 16 }, new Uint8Array(2)))
-    await assert.isFulfilled(iamap.create(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 10, bucketSize: 16 }, new Uint8Array((2 ** 10) / 8)))
+    await assert.isRejected(iamap.createInternal(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 4, bucketSize: 16 }, 'blerk'))
+    await assert.isRejected(iamap.createInternal(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 10, bucketSize: 16 }, new Uint8Array(2)))
+    await assert.isFulfilled(iamap.createInternal(devnull, { hashAlg: 0x00 /* 'identity' */, bitWidth: 10, bucketSize: 16 }, new Uint8Array((2 ** 10) / 8)))
   })
 
   it('test abort signal', async () => {
@@ -81,11 +81,11 @@ describe('Errors', () => {
     const signal = controller.signal
     let map = await iamap.create(store, { hashAlg: 0x23 /* 'murmur3-32' */ })
     map = await map.set('foo', 'bar', { signal: controller.signal })
-    map = await iamap.load(store, map.id, undefined, { signal })
+    map = await iamap.load(store, map.id, { signal })
     assert.strictEqual(await map.get('foo', { signal }), 'bar')
 
     store.getStuck()
-    const assertion = assert.isRejected(iamap.load(store, map.id, undefined, { signal }), 'Aborted')
+    const assertion = assert.isRejected(iamap.load(store, map.id, { signal }), 'Aborted')
     controller.abort()
     await assertion
     assert.isRejected(map.set('bar', 'baz', { signal }), 'Aborted')

--- a/test/errors-test.js
+++ b/test/errors-test.js
@@ -81,11 +81,11 @@ describe('Errors', () => {
     const signal = controller.signal
     let map = await iamap.create(store, { hashAlg: 0x23 /* 'murmur3-32' */ })
     map = await map.set('foo', 'bar', { signal: controller.signal })
-    map = await iamap.load(store, map.id, undefined, { hashAlg: 0x23, signal })
+    map = await iamap.load(store, map.id, undefined, { signal })
     assert.strictEqual(await map.get('foo', { signal }), 'bar')
 
     store.getStuck()
-    const assertion = assert.isRejected(iamap.load(store, map.id, undefined, { hashAlg: 0x23, signal }), 'Aborted')
+    const assertion = assert.isRejected(iamap.load(store, map.id, undefined, { signal }), 'Aborted')
     controller.abort()
     await assertion
     assert.isRejected(map.set('bar', 'baz', { signal }), 'Aborted')

--- a/test/errors-test.js
+++ b/test/errors-test.js
@@ -81,11 +81,11 @@ describe('Errors', () => {
     const signal = controller.signal
     let map = await iamap.create(store, { hashAlg: 0x23 /* 'murmur3-32' */ })
     map = await map.set('foo', 'bar', { signal: controller.signal })
-    map = await iamap.load(store, map.id, undefined, undefined, { signal })
+    map = await iamap.load(store, map.id, undefined, { hashAlg: 0x23, signal })
     assert.strictEqual(await map.get('foo', { signal }), 'bar')
 
     store.getStuck()
-    const assertion = assert.isRejected(iamap.load(store, map.id, undefined, undefined, { signal }), 'Aborted')
+    const assertion = assert.isRejected(iamap.load(store, map.id, undefined, { hashAlg: 0x23, signal }), 'Aborted')
     controller.abort()
     await assertion
     assert.isRejected(map.set('bar', 'baz', { signal }), 'Aborted')

--- a/test/interface.ts
+++ b/test/interface.ts
@@ -4,4 +4,6 @@ export interface TestStore extends Store<number> {
   map: Map<number, any>,
   saves: number,
   loads: number
+  /** Force the next load/save operation to get stuck and wait for signal.abort() */
+  getStuck(): void
 }

--- a/test/serialization-test.js
+++ b/test/serialization-test.js
@@ -69,7 +69,7 @@ describe('Serialization', () => {
     const emptySerialized = [dmap, []]
     const id = await store.save(emptySerialized)
 
-    const map = await iamap.load(store, id, 10, {
+    const map = await iamap.loadInternal(store, id, 10, {
       hashAlg: 0x00 /* 'identity' */,
       bitWidth: 7,
       bucketSize: 30
@@ -134,7 +134,7 @@ describe('Serialization', () => {
     // @ts-ignore
     id = await store.save(emptySerialized)
     // @ts-ignore
-    await assert.isRejected(iamap.load(store, id, 'foo'))
+    await assert.isRejected(iamap.loadInternal(store, id, 'foo'))
 
     emptySerialized = Object.assign({}, emptySerialized) // clone
     // @ts-ignore
@@ -155,7 +155,7 @@ describe('Serialization', () => {
     /** @type {SerializedNode} */
     let emptyChildSerialized = [mapCopy, []]
     id = await store.save(emptyChildSerialized)
-    assert.isFulfilled(iamap.load(store, id, 32, {
+    assert.isFulfilled(iamap.loadInternal(store, id, 32, {
       hashAlg: 0x00 /* 'identity' */,
       bitWidth: 8,
       bucketSize: 30
@@ -163,7 +163,7 @@ describe('Serialization', () => {
 
     emptyChildSerialized = /** @type {SerializedNode} */ (emptyChildSerialized.slice()) // clone
     id = await store.save(emptyChildSerialized)
-    await assert.isRejected(iamap.load(store, id, 33, { // this is not OK for a bitWidth of 8 and hash bytes of 32
+    await assert.isRejected(iamap.loadInternal(store, id, 33, { // this is not OK for a bitWidth of 8 and hash bytes of 32
       hashAlg: 0x00 /* 'identity' */,
       bitWidth: 8,
       bucketSize: 30
@@ -245,21 +245,21 @@ describe('Serialization', () => {
       bucketSize: 30
     })) // no hashAlg
 
-    await assert.isRejected(iamap.load(store, id, 32, {
+    await assert.isRejected(iamap.loadInternal(store, id, 32, {
       // @ts-ignore
       hashAlg: { yoiks: true },
       bitWidth: 8,
       bucketSize: 30
     })) // bad hashAlg
 
-    await assert.isRejected(iamap.load(store, id, 32, {
+    await assert.isRejected(iamap.loadInternal(store, id, 32, {
       hashAlg: 0x00 /* 'identity' */,
       // @ts-ignore
       bitWidth: 'foo',
       bucketSize: 30
     })) // bad bitWidth
 
-    await assert.isRejected(iamap.load(store, id, 32, {
+    await assert.isRejected(iamap.loadInternal(store, id, 32, {
       hashAlg: 0x00 /* 'identity' */,
       bitWidth: 8,
       // @ts-ignore


### PR DESCRIPTION
Addresses #23 

Let me know what you think, @rvagg.

I tried to follow js-ipfs style here.
Admittedly, `iamap.load(store, id, undefined, undefined, { signal })` feels really weird.
But any other way would be a breaking change.

Let me know if you'd prefer the breaking change `iamap.load(store, id, { signal })` instead (i.e. move the other parameters backwards), or something else.